### PR TITLE
fix: move stars behind content using z-index container (#1)

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -30,7 +30,7 @@ function Stars() {
   const stars = Array.from({ length: 100 });
 
   return (
-    <>
+    <div className="starsContainer">
       {stars.map((_, i) => {
         const style = {
           top: `${Math.random() * 100}vh`,
@@ -49,7 +49,7 @@ function Stars() {
         };
         return <div key={i} className="star" style={style}></div>;
       })}
-    </>
+    </div>
   );
 }
 

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -51,3 +51,18 @@ footer {
   font-size: 0.8rem;
   border-top: 1px solid var(--color-gold);
 }
+
+.starsContainer {
+  position: fixed;
+  top: 0; 
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: -1;          
+  overflow: hidden;
+  pointer-events: none; 
+}
+
+.star {
+  position: absolute;   
+}


### PR DESCRIPTION
## Descripción
Este Pull Request mueve la capa de estrellas al fondo real de la aplicación para evitar que se superponga con el contenido. También se reorganiza la posición de las estrellas dentro de un contenedor fijo con z-index negativo y se asegura que no bloqueen clics.

## Issue relacionada
Closes #1

## ¿Qué se hizo?
- Se creó un contenedor .starsContainer para manejar la posición de las estrellas.
- Se movieron las estrellas a position: absolute dentro del contenedor.
- Se aplicó position: fixed y z-index: -1 al contenedor para que quede detrás del contenido.
- Se añadió pointer-events: none para evitar interferencias con clics.
- Se reorganizó el código de Stars() para mayor claridad.


## ¿Cómo probarlo?
1. Ejecutar npm run dev.
2. Abrir la home.
3. Confirmar que las estrellas se ven, pero están detrás del contenido.
4. Hacer clic en los enlaces, cartas y botones para comprobar que ya no están bloqueados.
5. Revisar la animación para asegurarse de que funciona correctamente.

## Checklist
- [x] El código funciona en local
- [x] Cumple con lo pedido en la issue
- [x] No rompe nada existente
- [x] Código limpio y legible
